### PR TITLE
Create new dummy project using netstandard2.0 to allow compatibility with FABLE.

### DIFF
--- a/ArmEmulator/Arithmetic.fs
+++ b/ArmEmulator/Arithmetic.fs
@@ -440,7 +440,7 @@ module Arithmetic
         match parseArithLine operands symTable with
         | Ok (dest, op1, op2) -> 
             // Converts suffix string into bool option
-            let suffType = suffix.EndsWith('S') 
+            let suffType = suffix.EndsWith("S") 
 
             // Creates basic ArithInstr type
             let baseArithInstr = {

--- a/ArmEmulator/EmulatorInterface.fsproj
+++ b/ArmEmulator/EmulatorInterface.fsproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="VisualTesting/VisualTest/VTest.fs" />
+    <Compile Include="CommonData.fs" />
+    <Compile Include="CommonLex.fs" />
+    <Compile Include="ParseExpr.fs" />
+    <Compile Include="Arithmetic.fs" />
+    <Compile Include="ArithmeticTests.fs" />
+    <Compile Include="BitArithmetic.fs" />
+    <Compile Include="BitArithmeticTests.fs" />
+    <Compile Include="memInstructions.fs" />
+    <Compile Include="memInstructionsTests.fs" />
+    <Compile Include="MultMem.fs" />
+    <Compile Include="MultMemTests.fs" />
+    <Compile Include="ParseExprTests.fs" />
+    <Compile Include="Main.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Expecto" Version="5.1.1" />
+    <PackageReference Include="Expecto.FsCheck" Version="5.1.1" />
+  </ItemGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+ </Project>

--- a/ArmEmulator/EmulatorInterface.fsproj
+++ b/ArmEmulator/EmulatorInterface.fsproj
@@ -1,3 +1,10 @@
+<!--
+      This is a dummy project that uses TargetFramework: netstandard2.0
+      instead of the normal netcoreapp2.0
+      This allows the whole repo to be used as a submodule, as in:
+      https://github.com/djb15/arm-emulator-gui
+-->
+
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>

--- a/ArmEmulator/MultMem.fs
+++ b/ArmEmulator/MultMem.fs
@@ -91,7 +91,7 @@ module MultMem
         // get the target register as a string, e.g. "R10!"
         let targetStr = sLst.Head
         // check for writeback suffix '!'
-        let wb = targetStr.EndsWith('!')
+        let wb = targetStr.EndsWith("!")
         // get the target register's RName from string without '!' suffix
         let target = regNames.TryFind (targetStr.Trim('!'))
         // recombine the list of registers

--- a/ArmEmulator/ParseExpr.fs
+++ b/ArmEmulator/ParseExpr.fs
@@ -20,8 +20,8 @@ module ParseExpr
 
     /// checks if a string contains a character
     /// if so, split at that character and return list
-    let (|SplitAt|_|) (c:string) (str:string) =
-        if str.Contains(c) 
+    let (|SplitAt|_|) (c:char) (str:string) =
+        if str.Contains(c.ToString()) 
         then Some(str.Split(c) |> Seq.toList)
         else None
 


### PR DESCRIPTION
FABLE requires that we use netstandard2.0 as a build target. We could switch entirely, but that means we wouldn't be able to run our tests easily. So instead, I've created a second, dummy project file `EmulatorInterface.fsproj` which can be used by the GUI to build the project in the `netstandard2.0` form, while we can at the same time develop using `netcoreapp2.0`.